### PR TITLE
Fix call to getsockopt

### DIFF
--- a/src/swirly/sys/Socket.hpp
+++ b/src/swirly/sys/Socket.hpp
@@ -671,7 +671,7 @@ inline std::error_code get_so_error(int sockfd, std::error_code& ec) noexcept
 {
     int optval{};
     socklen_t optlen{sizeof(optval)};
-    os::getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &optval, optlen);
+    os::getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &optval, optlen, ec);
     return os::make_error(optval);
 }
 


### PR DESCRIPTION
The get_so_error noexcept overload must not throw.